### PR TITLE
fix console command

### DIFF
--- a/src/amber_cmd/commands/console.cr
+++ b/src/amber_cmd/commands/console.cr
@@ -9,7 +9,7 @@ module Amber::CMD
       command_name "console"
 
       def run
-        libs = ["require \"amber\"", "require \"./config/*\""] of String
+        libs = ["require \"amber\"", "require \"./src/controllers/*\"", "require \"./src/models/*\"", "require \"./src/jobs/*\"", "require \"./src/mailers/*\"", "require \"./src/views/*\"", "require \"./config/*\""] of String
         code = libs.join ';'
         Icr::Console.new(true).start(code)
       end

--- a/src/amber_cmd/commands/release.cr
+++ b/src/amber_cmd/commands/release.cr
@@ -7,7 +7,7 @@ module Amber::CMD
   class MainCommand < Cli::Supercommand
     command "r", aliased: "release"
 
-    class Console < Cli::Command
+    class Release < Cli::Command
       command_name "release"
 
       def run


### PR DESCRIPTION
This addresses a couple issues with the Console command:

1. There was a bug that the Release command was using the Console class name.

2. We need to require the source code when loading the console.   We cannot load the primary application source otherwise it will run the app and freeze the console. 