### PR TITLE
Fix script tag on ECR layout

### DIFF
--- a/src/templates/app/src/views/layouts/application.ecr.ecr
+++ b/src/templates/app/src/views/layouts/application.ecr.ecr
@@ -33,8 +33,8 @@
         </div>
       </div>
 
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js" />
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js" />
-    <script src="/javascripts/main.js" />
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
+    <script src="/javascripts/main.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Currently script tag doesn't work:

![screenshot_20170722_074144](https://user-images.githubusercontent.com/3067335/28491194-55417ddc-6eb2-11e7-98a4-691a74ee4fc3.png)

With this PR:

![screenshot_20170722_074443](https://user-images.githubusercontent.com/3067335/28491197-5d1526d0-6eb2-11e7-958a-1c4752c081b3.png)

